### PR TITLE
v1.57.6 (Hotfix 1) merge

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,6 +1,7 @@
 [
   [
 	["1.57.6", 15706],
+	"hotfix 1: in-game tooltip being stuck on screen",
 	"fixes: item-info ele dps, map-tracker unique maps",
 	"item-info: added support for new/renamed item-bases and uniques",
 	"act-tracker: added support for 0.2.0 pob imports",

--- a/data/versions.json
+++ b/data/versions.json
@@ -1,3 +1,4 @@
 {
-  "_release": [15706, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"]
+  "_release": [15706, "https://github.com/Lailloken/Lailloken-UI/archive/refs/heads/main.zip"],
+  "hotfix": 1
 }

--- a/modules/omni-key.ahk
+++ b/modules/omni-key.ahk
@@ -34,7 +34,7 @@
 		Else SendInput, !^{c}
 
 		ClipWait, 0.1
-		If !vars.poe_version && !settings.general.dev
+		If vars.poe_version && !settings.general.dev
 			If settings.hotkeys.item_descriptions && settings.hotkeys.rebound_alt
 				SendInput, % "{" settings.hotkeys.item_descriptions " up}"
 			Else SendInput, {ALT up}


### PR DESCRIPTION
- hotfix 1: in-game tooltip being stuck on screen
- fixes: item-info ele dps, map-tracker unique maps
- item-info: added support for new/renamed item-bases and uniques
- act-tracker: added support for 0.2.0 pob imports
- map-tracker: added support for new unique maps