### PR TITLE
Fix Map Tracker logging for The Black Barya

### DIFF
--- a/data/english/client.txt
+++ b/data/english/client.txt
@@ -104,6 +104,8 @@
 		maps_xesht			=	"twisted domain"		;## the map-name of the xesht fight
 		maps_arbiter			=	"arbiter of ash"
 		maps_arbiter			=	"the burning monolith"		;## the map-name of the arbiter fight
+		maps_saresh			=	"saresh"
+		maps_saresh			=	"the black barya"		;## the map-name of the saresh fight
 
 
 		maps_hideout			=	"hideout"			;## PoE2 only (whole block), claimable hideout on the atlas (separate key/value pair in case more hideouts are added in the future)

--- a/modules/client log.ahk
+++ b/modules/client log.ahk
@@ -226,7 +226,7 @@ Log_Get(log_text, data)
 	static unique_maps := {"merchant": "seer", "vault": "vaults"}
 
 	If (data = "areaname")
-		If !LLK_StringCompare(log_text, ["map", "breach", "ritual"])
+		If !LLK_StringCompare(log_text, ["map", "breach", "ritual", "FaridunLeagueBoss"])
 			%data% := log_text
 		Else
 		{
@@ -247,6 +247,12 @@ Log_Get(log_text, data)
 				If settings.maptracker.rename
 					Return Lang_Trans("maps_boss") ": " Lang_Trans("maps_arbiter")
 				Else Return Lang_Trans("maps_arbiter", 2) " (" Lang_Trans("maps_boss") ")"
+			}
+			Else If (log_text = "FaridunLeagueBoss")
+			{
+				If settings.maptracker.rename
+					Return Lang_Trans("maps_boss") ": " Lang_Trans("maps_saresh")
+				Else Return Lang_Trans("maps_saresh", 2) " (" Lang_Trans("maps_boss") ")"
 			}
 			Else If RegExMatch(log_text, "Hideout.*_Claimable")
 			{

--- a/modules/map tracker.ahk
+++ b/modules/map tracker.ahk
@@ -146,7 +146,7 @@ Maptracker_Check(mode := 0) ;checks if player is in a map or map-related content
 	global vars, settings
 
 	mode_check := (vars.poe_version ? ["abyss_depths", "abyss_boss"] : ["abyssleague", "endgame_labyrinth_trials", "mapsidearea", "SettlersBossFallenStar"])
-	For key, val in (vars.poe_version ? {"map": 0, "breach": 0, "ritual": 0, "abyss_depths": 0, "abyss_boss": 0} : {"mapworlds": 0, "maven": 0, "betrayal": 0, "incursion": 0, "heist": "heisthub", "mapatziri": 0, "legionleague": 0, "expedition": 0, "atlasexilesboss": 0, "breachboss": 0, "affliction": 0, "bestiary": 0, "sanctum": "sanctumfoyer", "synthesis": 0, "abyssleague": 0, "endgame_labyrinth_trials": 0, "mapsidearea": 0, "azmeri": 0, "SettlersBossFallenStar": 0, "HarvestLeagueBoss": 0, "ChayulaLeagueTowerBoss": 0})
+	For key, val in (vars.poe_version ? {"map": 0, "breach": 0, "ritual": 0, "abyss_depths": 0, "abyss_boss": 0, "FaridunLeagueBoss": 0} : {"mapworlds": 0, "maven": 0, "betrayal": 0, "incursion": 0, "heist": "heisthub", "mapatziri": 0, "legionleague": 0, "expedition": 0, "atlasexilesboss": 0, "breachboss": 0, "affliction": 0, "bestiary": 0, "sanctum": "sanctumfoyer", "synthesis": 0, "abyssleague": 0, "endgame_labyrinth_trials": 0, "mapsidearea": 0, "azmeri": 0, "SettlersBossFallenStar": 0, "HarvestLeagueBoss": 0, "ChayulaLeagueTowerBoss": 0})
 	{
 		If !mode && !Blank(LLK_HasVal(mode_check, key)) || (mode = 1) && Blank(LLK_HasVal(mode_check, key))
 			Continue


### PR DESCRIPTION
﻿## Summary

- Recognize the PoE2 `FaridunLeagueBoss` area id as map-tracker content.
- Give that client-log area id the same readable boss/map naming treatment used for Xesht and Arbiter.
- Add English strings for `saresh` / `the black barya`.

Fixes #760.

## Why

The Black Barya is a PoE2 map area, but its client-log area id does not start with the existing PoE2 map prefixes (`map`, `breach`, `ritual`, `abyss_*`). Because of that, `Maptracker_Check()` treated it as outside tracked map content and the run was never logged.

## Validation

- `git diff --check`
- Compiled `Exile UI.ahk` with `Ahk2Exe.exe` successfully; output executable was created at `%TEMP%\ExileUI_syntax_check.exe`.
